### PR TITLE
Http receptor requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,31 @@
 class ApplicationController < ActionController::API
+  SOCKET_PATH = "/tmp/receptor.sock".freeze
+  DELIM = "\x1b[K".freeze
+
+  protected
+
+  def send_directive(directive, recipient, payload, socket_path = SOCKET_PATH)
+    socket = UNIXSocket.new(socket_path)
+    socket.send("#{recipient}\n#{directive}\n#{payload}" + DELIM, 0)
+    response = ''
+    loop do
+      received = socket.recv(1024)
+      done = received.include?(DELIM)
+      received.sub!(DELIM, '') if done
+
+      response += received
+      break if done
+    end
+    response
+  ensure
+    socket.close
+  end
+
+  def identity_headers(tenant)
+    {
+      "x-rh-identity" => Base64.strict_encode64(
+        JSON.dump({"identity" => {"account_number" => tenant}})
+      )
+    }
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'socket'
+
 class ApplicationController < ActionController::API
   SOCKET_PATH = "/tmp/receptor.sock".freeze
   DELIM = "\x1b[K".freeze
@@ -19,13 +21,5 @@ class ApplicationController < ActionController::API
     response
   ensure
     socket.close
-  end
-
-  def identity_headers(tenant)
-    {
-      "x-rh-identity" => Base64.strict_encode64(
-        JSON.dump({"identity" => {"account_number" => tenant}})
-      )
-    }
   end
 end

--- a/app/controllers/http_request_controller.rb
+++ b/app/controllers/http_request_controller.rb
@@ -1,0 +1,23 @@
+class HttpRequestController < ApplicationController
+  DIRECTIVE_NAME = "receptor_http:execute".freeze
+
+  # POST /http_request
+  def send
+    response = send_directive(DIRECTIVE_NAME,
+                              params_for_receptor[:receptor_name],
+                              params_for_receptor[:payload])
+
+    parsed_response = JSON.parse(response)
+
+    render :json => parsed_response.dig('raw_payload', 'body'), :status => parsed_response.dig('raw_payload', 'status')
+  end
+
+  private
+
+  def params_for_receptor
+    @params_for_receptor ||= params.permit(
+      :receptor_name,
+      :payload => %i[method url headers data]
+    )
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,15 +1,12 @@
 require 'socket'
 
 class OrdersController < ApplicationController
-  SOCKET_PATH = "/tmp/receptor.sock".freeze
-  DELIM = "\x1b[K".freeze
-
+  # GET
   def index
-    target_receptor = "node-a" # This name has to be in sources db
     payload = {
       'method'  => 'GET',
       'url'     => "http://localhost:3002/api/sources/v1.0/sources",
-      'headers' => identity_headers('1460290')
+      'headers' => identity_headers(external_tenant)
     }
     response = send_directive("receptor_http:execute",
                               target_receptor,
@@ -17,33 +14,35 @@ class OrdersController < ApplicationController
 
     hash = JSON.parse(response)
 
-    render :plain => hash['raw_payload']['body']
+    render :json => hash.dig('raw_payload', 'body'), :status => hash.dig('raw_payload', 'status')
+  end
+
+  # GET
+  def source_update
+    payload = {
+      'method'  => 'PATCH',
+      'url'     => "http://localhost:3002/api/sources/v1.0/sources/2",
+      'data'    => {'name' => 'Openshift Changed'}.to_json,
+      'headers' => identity_headers(external_tenant)
+    }
+
+    response = send_directive("receptor_http:execute",
+                              target_receptor,
+                              payload.to_json)
+
+    hash = JSON.parse(response)
+
+    render :json => hash.dig('raw_payload', 'body'), :status => hash.dig('raw_payload', 'status')
   end
 
   private
 
-  def send_directive(directive, recipient, payload, socket_path = SOCKET_PATH)
-    socket = UNIXSocket.new(socket_path)
-    socket.send("#{recipient}\n#{directive}\n#{payload}" + DELIM, 0)
-    response = ''
-    loop do
-      received = socket.recv(1024)
-      done = received.include?(DELIM)
-      received.sub!(DELIM, '') if done
-
-      response += received
-      break if done
-    end
-    response
-  ensure
-    socket.close
+  def external_tenant
+    '1460290'
   end
 
-  def identity_headers(tenant)
-    {
-      "x-rh-identity" => Base64.strict_encode64(
-        JSON.dump({"identity" => {"account_number" => tenant}})
-      )
-    }
+  # This name has to be in sources db
+  def target_receptor
+    "node-a"
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,49 @@
+require 'socket'
+
+class OrdersController < ApplicationController
+  SOCKET_PATH = "/tmp/receptor.sock".freeze
+  DELIM = "\x1b[K".freeze
+
+  def index
+    target_receptor = "node-a" # This name has to be in sources db
+    payload = {
+      'method'  => 'GET',
+      'url'     => "http://localhost:3002/api/sources/v1.0/sources",
+      'headers' => identity_headers('1460290')
+    }
+    response = send_directive("receptor_http:execute",
+                              target_receptor,
+                              payload.to_json)
+
+    hash = JSON.parse(response)
+
+    render :plain => hash['raw_payload']['body']
+  end
+
+  private
+
+  def send_directive(directive, recipient, payload, socket_path = SOCKET_PATH)
+    socket = UNIXSocket.new(socket_path)
+    socket.send("#{recipient}\n#{directive}\n#{payload}" + DELIM, 0)
+    response = ''
+    loop do
+      received = socket.recv(1024)
+      done = received.include?(DELIM)
+      received.sub!(DELIM, '') if done
+
+      response += received
+      break if done
+    end
+    response
+  ensure
+    socket.close
+  end
+
+  def identity_headers(tenant)
+    {
+      "x-rh-identity" => Base64.strict_encode64(
+        JSON.dump({"identity" => {"account_number" => tenant}})
+      )
+    }
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,3 @@
-require 'socket'
-
 class OrdersController < ApplicationController
   # GET
   def index
@@ -44,5 +42,13 @@ class OrdersController < ApplicationController
   # This name has to be in sources db
   def target_receptor
     "node-a"
+  end
+
+  def identity_headers(tenant)
+    {
+      "x-rh-identity" => Base64.strict_encode64(
+        JSON.dump({"identity" => {"account_number" => tenant}})
+      )
+    }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :orders
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
       get :source_update
     end
   end
+
+  post "/http_request", :to => 'http_request#send'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :orders
+  resources :orders, :only => [:index] do
+    collection do
+      get :source_update
+    end
+  end
 end


### PR DESCRIPTION
Based on #1.

This PR adds `POST /http_request`for sending `http_receptor:execute` directive to target receptor (with http plugin)